### PR TITLE
Make collection type optional and improve error message

### DIFF
--- a/aws-opensearchserverless-collection/docs/README.md
+++ b/aws-opensearchserverless-collection/docs/README.md
@@ -42,7 +42,7 @@ _Required_: No
 
 _Type_: String
 
-_Maximum_: <code>1000</code>
+_Maximum Length_: <code>1000</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -61,9 +61,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>3</code>
+_Minimum Length_: <code>3</code>
 
-_Maximum_: <code>32</code>
+_Maximum Length_: <code>32</code>
 
 _Pattern_: <code>^[a-z][a-z0-9-]{2,31}$</code>
 

--- a/aws-opensearchserverless-collection/docs/tag.md
+++ b/aws-opensearchserverless-collection/docs/tag.md
@@ -32,9 +32,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -46,7 +46,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-opensearchserverless-collection/src/main/java/software/amazon/opensearchserverless/collection/CreateHandler.java
+++ b/aws-opensearchserverless-collection/src/main/java/software/amazon/opensearchserverless/collection/CreateHandler.java
@@ -51,10 +51,6 @@ public class CreateHandler extends BaseHandlerStd {
             return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.InvalidRequest, "Name cannot be empty");
         }
 
-        if (StringUtils.isNullOrEmpty(model.getType())) {
-            return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.InvalidRequest, "Type cannot be empty");
-        }
-
         Map<String, String> allDesiredTags = Maps.newHashMap();
         allDesiredTags.putAll(Optional.ofNullable(request.getDesiredResourceTags()).orElse(Collections.emptyMap()));
         allDesiredTags.putAll(Optional.ofNullable(request.getSystemTags()).orElse(Collections.emptyMap()));

--- a/aws-opensearchserverless-collection/src/main/java/software/amazon/opensearchserverless/collection/CreateHandler.java
+++ b/aws-opensearchserverless-collection/src/main/java/software/amazon/opensearchserverless/collection/CreateHandler.java
@@ -1,6 +1,5 @@
 package software.amazon.opensearchserverless.collection;
 
-import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.opensearchserverless.OpenSearchServerlessClient;
 import software.amazon.awssdk.services.opensearchserverless.model.BatchGetCollectionRequest;
 import software.amazon.awssdk.services.opensearchserverless.model.BatchGetCollectionResponse;
@@ -9,9 +8,7 @@ import software.amazon.awssdk.services.opensearchserverless.model.ConflictExcept
 import software.amazon.awssdk.services.opensearchserverless.model.CreateCollectionRequest;
 import software.amazon.awssdk.services.opensearchserverless.model.CreateCollectionResponse;
 import software.amazon.awssdk.services.opensearchserverless.model.InternalServerException;
-import software.amazon.awssdk.services.opensearchserverless.model.ValidationException;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
-import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInternalFailureException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotStabilizedException;
@@ -121,12 +118,8 @@ public class CreateHandler extends BaseHandlerStd {
                 proxyClient.injectCredentialsAndInvokeV2(createCollectionRequest, proxyClient.client()::createCollection);
         } catch (ConflictException e) {
             throw new CfnAlreadyExistsException(ResourceModel.TYPE_NAME,createCollectionRequest.name(),e);
-        } catch (ValidationException e) {
-            throw new CfnInvalidRequestException(createCollectionRequest.toString(), e);
         } catch (InternalServerException e) {
             throw new CfnInternalFailureException(e);
-        } catch (AwsServiceException e) {
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
         }
         logger.log(String.format("%s successfully created. response: %s", ResourceModel.TYPE_NAME, createCollectionResponse));
         return createCollectionResponse;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Make collection type optional. If collection type is not specified, it gets defaulted to TIMESERIES.
Surface error messages from api calls to enable easier understanding of failures.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
