### PR TITLE
Reuse OpenSearchServerless Client across multiple calls.

### DIFF
--- a/aws-opensearchserverless-accesspolicy/pom.xml
+++ b/aws-opensearchserverless-accesspolicy/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <aws.java.sdk.version>2.17.198</aws.java.sdk.version>
+        <aws.java.sdk.version>2.19.12</aws.java.sdk.version>
         <cfn.generate.args/>
     </properties>
 
@@ -36,8 +36,8 @@
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/opensearchserverless -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>aws-java-sdk-opensearchserverless</artifactId>
-            <version>2.0</version>
+            <artifactId>opensearchserverless</artifactId>
+            <version>${aws.java.sdk.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/sdk-core -->
         <dependency>

--- a/aws-opensearchserverless-accesspolicy/src/main/java/software/amazon/opensearchserverless/accesspolicy/BaseHandlerStd.java
+++ b/aws-opensearchserverless-accesspolicy/src/main/java/software/amazon/opensearchserverless/accesspolicy/BaseHandlerStd.java
@@ -8,6 +8,21 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
+
+    private final OpenSearchServerlessClient openSearchServerlessClient;
+
+    protected BaseHandlerStd() {
+        this(ClientBuilder.getClient());
+    }
+
+    protected BaseHandlerStd(OpenSearchServerlessClient openSearchServerlessClient ) {
+        this.openSearchServerlessClient = openSearchServerlessClient;
+    }
+
+    private OpenSearchServerlessClient getOpenSearchServerlessClient() {
+        return openSearchServerlessClient;
+    }
+
     @Override
     public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
@@ -18,9 +33,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 proxy,
                 request,
                 callbackContext != null ? callbackContext : new CallbackContext(),
-                proxy.newProxy(ClientBuilder::getClient),
-                logger
-                            );
+                proxy.newProxy(this::getOpenSearchServerlessClient),
+                logger);
     }
 
     protected abstract ProgressEvent<ResourceModel, CallbackContext> handleRequest(

--- a/aws-opensearchserverless-accountsettings/pom.xml
+++ b/aws-opensearchserverless-accountsettings/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <aws.java.sdk.version>2.18.0</aws.java.sdk.version>
+        <aws.java.sdk.version>2.19.12</aws.java.sdk.version>
         <cfn.generate.args/>
     </properties>
 
@@ -36,8 +36,8 @@
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/opensearchserverless -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>aws-java-sdk-opensearchserverless</artifactId>
-            <version>2.0</version>
+            <artifactId>opensearchserverless</artifactId>
+            <version>${aws.java.sdk.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/sdk-core -->
         <dependency>

--- a/aws-opensearchserverless-accountsettings/src/main/java/software/amazon/opensearchserverless/accountsettings/BaseHandlerStd.java
+++ b/aws-opensearchserverless-accountsettings/src/main/java/software/amazon/opensearchserverless/accountsettings/BaseHandlerStd.java
@@ -8,6 +8,20 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
+    private final OpenSearchServerlessClient openSearchServerlessClient;
+
+    protected BaseHandlerStd() {
+        this(ClientBuilder.getClient());
+    }
+
+    protected BaseHandlerStd(OpenSearchServerlessClient openSearchServerlessClient ) {
+        this.openSearchServerlessClient = openSearchServerlessClient;
+    }
+
+    private OpenSearchServerlessClient getOpenSearchServerlessClient() {
+        return openSearchServerlessClient;
+    }
+
     @Override
     public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
         final AmazonWebServicesClientProxy proxy,
@@ -18,9 +32,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             proxy,
             request,
             callbackContext != null ? callbackContext : new CallbackContext(),
-            proxy.newProxy(ClientBuilder::getClient),
-            logger
-        );
+            proxy.newProxy(this::getOpenSearchServerlessClient),
+            logger);
     }
 
     protected abstract ProgressEvent<ResourceModel, CallbackContext> handleRequest(

--- a/aws-opensearchserverless-collection/pom.xml
+++ b/aws-opensearchserverless-collection/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <aws.java.sdk.version>2.17.198</aws.java.sdk.version>
+        <aws.java.sdk.version>2.19.12</aws.java.sdk.version>
         <cfn.generate.args/>
     </properties>
 
@@ -36,8 +36,8 @@
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/opensearchserverless -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>aws-java-sdk-opensearchserverless</artifactId>
-            <version>2.0</version>
+            <artifactId>opensearchserverless</artifactId>
+            <version>${aws.java.sdk.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/sdk-core -->
         <dependency>

--- a/aws-opensearchserverless-securityconfig/docs/README.md
+++ b/aws-opensearchserverless-securityconfig/docs/README.md
@@ -41,9 +41,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>1000</code>
+_Maximum Length_: <code>1000</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -55,9 +55,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>3</code>
+_Minimum Length_: <code>3</code>
 
-_Maximum_: <code>32</code>
+_Maximum Length_: <code>32</code>
 
 _Pattern_: <code>^[a-z][a-z0-9-]{2,31}$</code>
 

--- a/aws-opensearchserverless-securityconfig/docs/samlconfigoptions.md
+++ b/aws-opensearchserverless-securityconfig/docs/samlconfigoptions.md
@@ -36,9 +36,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>20480</code>
+_Maximum Length_: <code>20480</code>
 
 _Pattern_: <code>[\u0009\u000A\u000D\u0020-\u007E\u00A1-\u00FF]+</code>
 
@@ -52,9 +52,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>2048</code>
+_Maximum Length_: <code>2048</code>
 
 _Pattern_: <code>[\w+=,.@-]+</code>
 
@@ -68,9 +68,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>2048</code>
+_Maximum Length_: <code>2048</code>
 
 _Pattern_: <code>[\w+=,.@-]+</code>
 

--- a/aws-opensearchserverless-securityconfig/pom.xml
+++ b/aws-opensearchserverless-securityconfig/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <aws.java.sdk.version>2.17.198</aws.java.sdk.version>
+        <aws.java.sdk.version>2.19.12</aws.java.sdk.version>
         <cfn.generate.args/>
     </properties>
 
@@ -36,8 +36,8 @@
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/opensearchserverless -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>aws-java-sdk-opensearchserverless</artifactId>
-            <version>2.0</version>
+            <artifactId>opensearchserverless</artifactId>
+            <version>${aws.java.sdk.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/sdk-core -->
         <dependency>

--- a/aws-opensearchserverless-securityconfig/src/main/java/software/amazon/opensearchserverless/securityconfig/BaseHandlerStd.java
+++ b/aws-opensearchserverless-securityconfig/src/main/java/software/amazon/opensearchserverless/securityconfig/BaseHandlerStd.java
@@ -8,6 +8,21 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
+
+    private final OpenSearchServerlessClient openSearchServerlessClient;
+
+    protected BaseHandlerStd() {
+        this(ClientBuilder.getClient());
+    }
+
+    protected BaseHandlerStd(OpenSearchServerlessClient openSearchServerlessClient ) {
+        this.openSearchServerlessClient = openSearchServerlessClient;
+    }
+
+    private OpenSearchServerlessClient getOpenSearchServerlessClient() {
+        return openSearchServerlessClient;
+    }
+
     @Override
     public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
@@ -18,9 +33,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 proxy,
                 request,
                 callbackContext != null ? callbackContext : new CallbackContext(),
-                proxy.newProxy(ClientBuilder::getClient),
-                logger
-                            );
+                proxy.newProxy(this::getOpenSearchServerlessClient),
+                logger);
     }
 
     protected abstract ProgressEvent<ResourceModel, CallbackContext> handleRequest(

--- a/aws-opensearchserverless-securitypolicy/docs/README.md
+++ b/aws-opensearchserverless-securitypolicy/docs/README.md
@@ -41,9 +41,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>1000</code>
+_Maximum Length_: <code>1000</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -55,9 +55,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>20480</code>
+_Maximum Length_: <code>20480</code>
 
 _Pattern_: <code>[\u0009\u000A\u000D\u0020-\u007E\u00A1-\u00FF]+</code>
 
@@ -71,9 +71,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>3</code>
+_Minimum Length_: <code>3</code>
 
-_Maximum_: <code>32</code>
+_Maximum Length_: <code>32</code>
 
 _Pattern_: <code>^[a-z][a-z0-9-]{2,31}$</code>
 

--- a/aws-opensearchserverless-securitypolicy/pom.xml
+++ b/aws-opensearchserverless-securitypolicy/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <aws.java.sdk.version>2.17.198</aws.java.sdk.version>
+        <aws.java.sdk.version>2.19.12</aws.java.sdk.version>
         <cfn.generate.args/>
     </properties>
 
@@ -36,8 +36,8 @@
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/opensearchserverless -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>aws-java-sdk-opensearchserverless</artifactId>
-            <version>2.0</version>
+            <artifactId>opensearchserverless</artifactId>
+            <version>${aws.java.sdk.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/sdk-core -->
         <dependency>

--- a/aws-opensearchserverless-securitypolicy/src/main/java/software/amazon/opensearchserverless/securitypolicy/BaseHandlerStd.java
+++ b/aws-opensearchserverless-securitypolicy/src/main/java/software/amazon/opensearchserverless/securitypolicy/BaseHandlerStd.java
@@ -8,6 +8,21 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
+
+    private final OpenSearchServerlessClient openSearchServerlessClient;
+
+    protected BaseHandlerStd() {
+        this(ClientBuilder.getClient());
+    }
+
+    protected BaseHandlerStd(OpenSearchServerlessClient openSearchServerlessClient ) {
+        this.openSearchServerlessClient = openSearchServerlessClient;
+    }
+
+    private OpenSearchServerlessClient getOpenSearchServerlessClient() {
+        return openSearchServerlessClient;
+    }
+
     @Override
     public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
         final AmazonWebServicesClientProxy proxy,
@@ -18,9 +33,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             proxy,
             request,
             callbackContext != null ? callbackContext : new CallbackContext(),
-            proxy.newProxy(ClientBuilder::getClient),
-            logger
-        );
+            proxy.newProxy(this::getOpenSearchServerlessClient),
+            logger);
     }
 
     protected abstract ProgressEvent<ResourceModel, CallbackContext> handleRequest(

--- a/aws-opensearchserverless-vpcendpoint/docs/README.md
+++ b/aws-opensearchserverless-vpcendpoint/docs/README.md
@@ -43,9 +43,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>3</code>
+_Minimum Length_: <code>3</code>
 
-_Maximum_: <code>32</code>
+_Maximum Length_: <code>32</code>
 
 _Pattern_: <code>^[a-z][a-z0-9-]{2,31}$</code>
 
@@ -79,9 +79,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>255</code>
+_Maximum Length_: <code>255</code>
 
 _Pattern_: <code>^vpc-[0-9a-z]*$</code>
 

--- a/aws-opensearchserverless-vpcendpoint/pom.xml
+++ b/aws-opensearchserverless-vpcendpoint/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <aws.java.sdk.version>2.17.198</aws.java.sdk.version>
+        <aws.java.sdk.version>2.19.12</aws.java.sdk.version>
         <cfn.generate.args/>
     </properties>
 
@@ -36,8 +36,8 @@
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/opensearchserverless -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>aws-java-sdk-opensearchserverless</artifactId>
-            <version>2.0</version>
+            <artifactId>opensearchserverless</artifactId>
+            <version>${aws.java.sdk.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/sdk-core -->
         <dependency>

--- a/aws-opensearchserverless-vpcendpoint/src/main/java/software/amazon/opensearchserverless/vpcendpoint/BaseHandlerStd.java
+++ b/aws-opensearchserverless-vpcendpoint/src/main/java/software/amazon/opensearchserverless/vpcendpoint/BaseHandlerStd.java
@@ -1,6 +1,5 @@
 package software.amazon.opensearchserverless.vpcendpoint;
 
-
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.opensearchserverless.OpenSearchServerlessClient;
@@ -19,6 +18,19 @@ import lombok.NonNull;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
   static final String INVALID_VpcEndpoint_ID_NOT_FOUND = "InvalidVpcEndpointID.NotFound";
+  private final OpenSearchServerlessClient openSearchServerlessClient;
+
+  protected BaseHandlerStd() {
+    this(ClientBuilder.getClient());
+  }
+
+  protected BaseHandlerStd(OpenSearchServerlessClient openSearchServerlessClient ) {
+    this.openSearchServerlessClient = openSearchServerlessClient;
+  }
+
+  private OpenSearchServerlessClient getOpenSearchServerlessClient() {
+    return openSearchServerlessClient;
+  }
 
   @Override
   public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
@@ -30,9 +42,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             proxy,
             request,
             callbackContext != null ? callbackContext : new CallbackContext(),
-            proxy.newProxy(ClientBuilder::getClient),
-            logger
-                        );
+            proxy.newProxy(this::getOpenSearchServerlessClient),
+            logger);
   }
 
   protected abstract ProgressEvent<ResourceModel, CallbackContext> handleRequest(
@@ -57,7 +68,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
       return response;
     }
     throw new CfnNotFoundException(ResourceModel.TYPE_NAME, batchGetVpcEndpointRequest.ids().get(0));
-
   }
 
   /**


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Reuse the OpenSearchServerless serverless client across multiple calls and threads.

ref: https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/creating-clients.html
Service clients in the SDK are thread-safe and, for best performance, you should treat them as long-lived objects: 

2. Update dependencies to latest sdk

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
