### PR TITLE
Upgrade java

### DIFF
--- a/.github/workflows/java-ci-with-maven.yml
+++ b/.github/workflows/java-ci-with-maven.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:

--- a/aws-opensearchserverless-accesspolicy/.rpdk-config
+++ b/aws-opensearchserverless-accesspolicy/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::OpenSearchServerless::AccessPolicy",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java11",
     "entrypoint": "software.amazon.opensearchserverless.accesspolicy.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.opensearchserverless.accesspolicy.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-opensearchserverless-accesspolicy/pom.xml
+++ b/aws-opensearchserverless-accesspolicy/pom.xml
@@ -12,8 +12,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <aws.java.sdk.version>2.21.7</aws.java.sdk.version>

--- a/aws-opensearchserverless-accesspolicy/template.yml
+++ b/aws-opensearchserverless-accesspolicy/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.opensearchserverless.accesspolicy.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java11
       CodeUri: ./target/aws-opensearchserverless-accesspolicy-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.opensearchserverless.accesspolicy.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java11
       CodeUri: ./target/aws-opensearchserverless-accesspolicy-handler-1.0-SNAPSHOT.jar

--- a/aws-opensearchserverless-accountsettings/.rpdk-config
+++ b/aws-opensearchserverless-accountsettings/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::OpenSearchServerless::AccountSettings",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java11",
     "entrypoint": "software.amazon.opensearchserverless.accountsettings.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.opensearchserverless.accountsettings.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-opensearchserverless-accountsettings/pom.xml
+++ b/aws-opensearchserverless-accountsettings/pom.xml
@@ -12,8 +12,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <aws.java.sdk.version>2.21.7</aws.java.sdk.version>

--- a/aws-opensearchserverless-accountsettings/template.yml
+++ b/aws-opensearchserverless-accountsettings/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.opensearchserverless.accountsettings.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java11
       CodeUri: ./target/aws-opensearchserverless-accountsettings-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.opensearchserverless.accountsettings.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java11
       CodeUri: ./target/aws-opensearchserverless-accountsettings-handler-1.0-SNAPSHOT.jar

--- a/aws-opensearchserverless-collection/.rpdk-config
+++ b/aws-opensearchserverless-collection/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::OpenSearchServerless::Collection",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java11",
     "entrypoint": "software.amazon.opensearchserverless.collection.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.opensearchserverless.collection.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-opensearchserverless-collection/pom.xml
+++ b/aws-opensearchserverless-collection/pom.xml
@@ -12,8 +12,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <aws.java.sdk.version>2.21.7</aws.java.sdk.version>

--- a/aws-opensearchserverless-collection/template.yml
+++ b/aws-opensearchserverless-collection/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.opensearchserverless.collection.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java11
       CodeUri: ./target/aws-opensearchserverless-collection-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.opensearchserverless.collection.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java11
       CodeUri: ./target/aws-opensearchserverless-collection-handler-1.0-SNAPSHOT.jar

--- a/aws-opensearchserverless-lifecyclepolicy/.rpdk-config
+++ b/aws-opensearchserverless-lifecyclepolicy/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::OpenSearchServerless::LifecyclePolicy",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java11",
     "entrypoint": "software.amazon.opensearchserverless.lifecyclepolicy.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.opensearchserverless.lifecyclepolicy.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-opensearchserverless-lifecyclepolicy/pom.xml
+++ b/aws-opensearchserverless-lifecyclepolicy/pom.xml
@@ -12,8 +12,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <aws.java.sdk.version>2.21.7</aws.java.sdk.version>

--- a/aws-opensearchserverless-lifecyclepolicy/template.yml
+++ b/aws-opensearchserverless-lifecyclepolicy/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.opensearchserverless.lifecyclepolicy.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java11
       CodeUri: ./target/aws-opensearchserverless-lifecyclepolicy-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.opensearchserverless.lifecyclepolicy.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java11
       CodeUri: ./target/aws-opensearchserverless-lifecyclepolicy-handler-1.0-SNAPSHOT.jar

--- a/aws-opensearchserverless-securityconfig/.rpdk-config
+++ b/aws-opensearchserverless-securityconfig/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::OpenSearchServerless::SecurityConfig",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java11",
     "entrypoint": "software.amazon.opensearchserverless.securityconfig.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.opensearchserverless.securityconfig.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-opensearchserverless-securityconfig/pom.xml
+++ b/aws-opensearchserverless-securityconfig/pom.xml
@@ -12,8 +12,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <aws.java.sdk.version>2.21.7</aws.java.sdk.version>

--- a/aws-opensearchserverless-securityconfig/template.yml
+++ b/aws-opensearchserverless-securityconfig/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.opensearchserverless.securityconfig.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java11
       CodeUri: ./target/aws-opensearchserverless-securityconfig-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.opensearchserverless.securityconfig.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java11
       CodeUri: ./target/aws-opensearchserverless-securityconfig-handler-1.0-SNAPSHOT.jar

--- a/aws-opensearchserverless-securitypolicy/.rpdk-config
+++ b/aws-opensearchserverless-securitypolicy/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::OpenSearchServerless::SecurityPolicy",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java11",
     "entrypoint": "software.amazon.opensearchserverless.securitypolicy.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.opensearchserverless.securitypolicy.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-opensearchserverless-securitypolicy/pom.xml
+++ b/aws-opensearchserverless-securitypolicy/pom.xml
@@ -12,8 +12,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <aws.java.sdk.version>2.21.7</aws.java.sdk.version>

--- a/aws-opensearchserverless-securitypolicy/template.yml
+++ b/aws-opensearchserverless-securitypolicy/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.opensearchserverless.securitypolicy.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java11
       CodeUri: ./target/aws-opensearchserverless-securitypolicy-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.opensearchserverless.securitypolicy.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java11
       CodeUri: ./target/aws-opensearchserverless-securitypolicy-handler-1.0-SNAPSHOT.jar

--- a/aws-opensearchserverless-vpcendpoint/.rpdk-config
+++ b/aws-opensearchserverless-vpcendpoint/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::OpenSearchServerless::VpcEndpoint",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java11",
     "entrypoint": "software.amazon.opensearchserverless.vpcendpoint.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.opensearchserverless.vpcendpoint.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-opensearchserverless-vpcendpoint/pom.xml
+++ b/aws-opensearchserverless-vpcendpoint/pom.xml
@@ -12,8 +12,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <aws.java.sdk.version>2.21.7</aws.java.sdk.version>

--- a/aws-opensearchserverless-vpcendpoint/template.yml
+++ b/aws-opensearchserverless-vpcendpoint/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.opensearchserverless.vpcendpoint.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java11
       CodeUri: ./target/aws-opensearchserverless-vpcendpoint-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.opensearchserverless.vpcendpoint.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java11
       CodeUri: ./target/aws-opensearchserverless-vpcendpoint-handler-1.0-SNAPSHOT.jar


### PR DESCRIPTION
*Issue #, if available:*
We received Sev3 tickets from Uluru to Upgrade to Java11 from Java8 before it is deprecated by 12/31.
Example ticket: https://tt.amazon.com/V1152306963/overview

*Description of changes:*
Updated the following files in all the modules:
.rpdk-config
template.yml
pom.xml

*Testing*
`mvn clean package`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
