### PR TITLE
Fix Exception handling for Policies

### DIFF
--- a/aws-opensearchserverless-accesspolicy/src/main/java/software/amazon/opensearchserverless/accesspolicy/CreateHandler.java
+++ b/aws-opensearchserverless-accesspolicy/src/main/java/software/amazon/opensearchserverless/accesspolicy/CreateHandler.java
@@ -5,10 +5,12 @@ import software.amazon.awssdk.services.opensearchserverless.model.ConflictExcept
 import software.amazon.awssdk.services.opensearchserverless.model.CreateAccessPolicyRequest;
 import software.amazon.awssdk.services.opensearchserverless.model.CreateAccessPolicyResponse;
 import software.amazon.awssdk.services.opensearchserverless.model.InternalServerException;
+import software.amazon.awssdk.services.opensearchserverless.model.ServiceQuotaExceededException;
 import software.amazon.awssdk.services.opensearchserverless.model.ValidationException;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
+import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -63,10 +65,16 @@ public class CreateHandler extends BaseHandlerStd {
             logger.log(String.format("Sending create access policy request: %s", createAccessPolicyRequest));
             createAccessPolicyResponse = proxyClient.injectCredentialsAndInvokeV2(createAccessPolicyRequest, proxyClient.client()::createAccessPolicy);
         } catch (ConflictException e) {
-            throw new CfnAlreadyExistsException(ResourceModel.TYPE_NAME, String.format("Name:%s, Type:%s",
-                    createAccessPolicyRequest.name(), createAccessPolicyRequest.typeAsString()), e);
+            if (e.getMessage()!= null && e.getMessage().contains("already exists")) {
+                throw new CfnAlreadyExistsException(ResourceModel.TYPE_NAME, String.format("Name:%s, Type:%s",
+                        createAccessPolicyRequest.name(), createAccessPolicyRequest.typeAsString()), e);
+            } else {
+                throw new CfnInvalidRequestException(createAccessPolicyRequest.toString() + ", " + e.getMessage(), e);
+            }
         } catch (ValidationException e) {
             throw new CfnInvalidRequestException(createAccessPolicyRequest.toString() + ", " + e.getMessage(), e);
+        } catch (ServiceQuotaExceededException e) {
+            throw new CfnServiceLimitExceededException(e);
         } catch (InternalServerException e) {
             throw new CfnServiceInternalErrorException("CreateAccessPolicy", e);
         }

--- a/aws-opensearchserverless-accesspolicy/src/main/java/software/amazon/opensearchserverless/accesspolicy/Translator.java
+++ b/aws-opensearchserverless-accesspolicy/src/main/java/software/amazon/opensearchserverless/accesspolicy/Translator.java
@@ -140,9 +140,7 @@ public class Translator {
     }
 
     private static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {
-        return Optional.ofNullable(collection)
-                       .map(Collection::stream)
-                       .orElseGet(Stream::empty);
+        return Optional.ofNullable(collection).stream().flatMap(Collection::stream);
     }
 
     private static ResourceModel translateAccessPolicySummaryFromSDK(AccessPolicySummary accessPolicySummary) {
@@ -159,5 +157,15 @@ public class Translator {
                 .description(accessPolicyDetail.description())
                 .policy(accessPolicyDetail.policy().toString())
                 .build();
+    }
+
+    static String getResourceIdentifierForUpdateAccessPolicyRequest(
+        final UpdateAccessPolicyRequest updateAccessPolicyRequest) {
+        return String.format("%s|%s", updateAccessPolicyRequest.typeAsString(), updateAccessPolicyRequest.name());
+    }
+
+    static String getResourceIdentifierForGetAccessPolicyRequest(
+        final GetAccessPolicyRequest getAccessPolicyRequest) {
+        return String.format("%s|%s", getAccessPolicyRequest.typeAsString(), getAccessPolicyRequest.name());
     }
 }

--- a/aws-opensearchserverless-accesspolicy/src/main/java/software/amazon/opensearchserverless/accesspolicy/UpdateHandler.java
+++ b/aws-opensearchserverless-accesspolicy/src/main/java/software/amazon/opensearchserverless/accesspolicy/UpdateHandler.java
@@ -28,6 +28,9 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.amazonaws.util.StringUtils;
 
+import static software.amazon.opensearchserverless.accesspolicy.Translator.getResourceIdentifierForGetAccessPolicyRequest;
+import static software.amazon.opensearchserverless.accesspolicy.Translator.getResourceIdentifierForUpdateAccessPolicyRequest;
+
 public class UpdateHandler extends BaseHandlerStd {
 
     public UpdateHandler() {
@@ -115,11 +118,16 @@ public class UpdateHandler extends BaseHandlerStd {
             updateAccessPolicyResponse = proxyClient.injectCredentialsAndInvokeV2(updateAccessPolicyRequest,
                 proxyClient.client()::updateAccessPolicy);
         } catch (ResourceNotFoundException e) {
-            throw new CfnNotFoundException(e);
+            throw new CfnNotFoundException(ResourceModel.TYPE_NAME,
+                getResourceIdentifierForUpdateAccessPolicyRequest(updateAccessPolicyRequest),
+                e);
         } catch (ValidationException e) {
             throw new CfnInvalidRequestException(updateAccessPolicyRequest.toString(), e);
         } catch (ConflictException e) {
-                throw new CfnResourceConflictException(ResourceModel.TYPE_NAME, updateAccessPolicyRequest.name(), e.getMessage(), e);
+            throw new CfnResourceConflictException(ResourceModel.TYPE_NAME,
+                getResourceIdentifierForUpdateAccessPolicyRequest(updateAccessPolicyRequest),
+                e.getMessage(),
+                e);
         } catch (ServiceQuotaExceededException e) {
             throw new CfnServiceLimitExceededException(e);
         } catch (InternalServerException e) {
@@ -142,8 +150,9 @@ public class UpdateHandler extends BaseHandlerStd {
             getAccessPolicyResponse = proxyClient.injectCredentialsAndInvokeV2(getAccessPolicyRequest,
                 proxyClient.client()::getAccessPolicy);
         } catch (ResourceNotFoundException e) {
-            throw new CfnNotFoundException(ResourceModel.TYPE_NAME,String.format("Name:%s, Type:%s",
-                getAccessPolicyRequest.name(), getAccessPolicyRequest.typeAsString()),e);
+            throw new CfnNotFoundException(ResourceModel.TYPE_NAME,
+                getResourceIdentifierForGetAccessPolicyRequest(getAccessPolicyRequest),
+                e);
         } catch (ValidationException e) {
             throw new CfnInvalidRequestException(getAccessPolicyRequest.toString(), e);
         } catch (InternalServerException e) {

--- a/aws-opensearchserverless-accesspolicy/src/main/java/software/amazon/opensearchserverless/accesspolicy/UpdateHandler.java
+++ b/aws-opensearchserverless-accesspolicy/src/main/java/software/amazon/opensearchserverless/accesspolicy/UpdateHandler.java
@@ -3,10 +3,12 @@ package software.amazon.opensearchserverless.accesspolicy;
 
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.opensearchserverless.OpenSearchServerlessClient;
+import software.amazon.awssdk.services.opensearchserverless.model.ConflictException;
 import software.amazon.awssdk.services.opensearchserverless.model.GetAccessPolicyRequest;
 import software.amazon.awssdk.services.opensearchserverless.model.GetAccessPolicyResponse;
 import software.amazon.awssdk.services.opensearchserverless.model.InternalServerException;
 import software.amazon.awssdk.services.opensearchserverless.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.opensearchserverless.model.ServiceQuotaExceededException;
 import software.amazon.awssdk.services.opensearchserverless.model.UpdateAccessPolicyRequest;
 import software.amazon.awssdk.services.opensearchserverless.model.UpdateAccessPolicyResponse;
 import software.amazon.awssdk.services.opensearchserverless.model.ValidationException;
@@ -14,7 +16,9 @@ import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInternalFailureException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
+import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -114,6 +118,10 @@ public class UpdateHandler extends BaseHandlerStd {
             throw new CfnNotFoundException(e);
         } catch (ValidationException e) {
             throw new CfnInvalidRequestException(updateAccessPolicyRequest.toString(), e);
+        } catch (ConflictException e) {
+                throw new CfnResourceConflictException(ResourceModel.TYPE_NAME, updateAccessPolicyRequest.name(), e.getMessage(), e);
+        } catch (ServiceQuotaExceededException e) {
+            throw new CfnServiceLimitExceededException(e);
         } catch (InternalServerException e) {
             throw new CfnServiceInternalErrorException(e);
         } catch (AwsServiceException e) {

--- a/aws-opensearchserverless-accesspolicy/src/test/java/software/amazon/opensearchserverless/accesspolicy/CreateHandlerTest.java
+++ b/aws-opensearchserverless-accesspolicy/src/test/java/software/amazon/opensearchserverless/accesspolicy/CreateHandlerTest.java
@@ -4,8 +4,16 @@ import software.amazon.awssdk.core.document.Document;
 import software.amazon.awssdk.services.opensearchserverless.OpenSearchServerlessClient;
 import software.amazon.awssdk.services.opensearchserverless.model.AccessPolicyDetail;
 import software.amazon.awssdk.services.opensearchserverless.model.AccessPolicyType;
+import software.amazon.awssdk.services.opensearchserverless.model.ConflictException;
 import software.amazon.awssdk.services.opensearchserverless.model.CreateAccessPolicyRequest;
 import software.amazon.awssdk.services.opensearchserverless.model.CreateAccessPolicyResponse;
+import software.amazon.awssdk.services.opensearchserverless.model.InternalServerException;
+import software.amazon.awssdk.services.opensearchserverless.model.ServiceQuotaExceededException;
+import software.amazon.awssdk.services.opensearchserverless.model.ValidationException;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
+import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -20,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -88,5 +97,114 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
+    }
+
+
+    @Test
+    public void handleRequest_AlreadyExists_Fail() {
+        when(openSearchServerlessClient.createAccessPolicy(any(CreateAccessPolicyRequest.class)))
+                .thenThrow(ConflictException.builder()
+                        .message(String.format("Policy with name %s and type %s already exists",
+                                MOCK_ACCESS_POLICY_NAME, MOCK_ACCESS_POLICY_TYPE))
+                        .build());
+
+        final CreateHandler handler = new CreateHandler(openSearchServerlessClient);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_ACCESS_POLICY_NAME)
+                .type(MOCK_ACCESS_POLICY_TYPE)
+                .description(MOCK_ACCESS_POLICY_DESCRIPTION)
+                .policy(MOCK_ACCESS_POLICY_DOCUMENT.toString())
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+
+        assertThrows(CfnAlreadyExistsException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).createAccessPolicy(any(CreateAccessPolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_ConflictException_Fail() {
+        when(openSearchServerlessClient.createAccessPolicy(any(CreateAccessPolicyRequest.class)))
+                .thenThrow(ConflictException.builder().build());
+
+        final CreateHandler handler = new CreateHandler(openSearchServerlessClient);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_ACCESS_POLICY_NAME)
+                .type(MOCK_ACCESS_POLICY_TYPE)
+                .description(MOCK_ACCESS_POLICY_DESCRIPTION)
+                .policy(MOCK_ACCESS_POLICY_DOCUMENT.toString())
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+
+        assertThrows(CfnInvalidRequestException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).createAccessPolicy(any(CreateAccessPolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_ValidationException_Fail() {
+        when(openSearchServerlessClient.createAccessPolicy(any(CreateAccessPolicyRequest.class)))
+                .thenThrow(ValidationException.builder().build());
+
+        final CreateHandler handler = new CreateHandler(openSearchServerlessClient);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_ACCESS_POLICY_NAME)
+                .type(MOCK_ACCESS_POLICY_TYPE)
+                .description(MOCK_ACCESS_POLICY_DESCRIPTION)
+                .policy(MOCK_ACCESS_POLICY_DOCUMENT.toString())
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+
+        assertThrows(CfnInvalidRequestException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).createAccessPolicy(any(CreateAccessPolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_ServiceQuotaExceededException_Fail() {
+        when(openSearchServerlessClient.createAccessPolicy(any(CreateAccessPolicyRequest.class)))
+                .thenThrow(ServiceQuotaExceededException.builder().build());
+
+        final CreateHandler handler = new CreateHandler(openSearchServerlessClient);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_ACCESS_POLICY_NAME)
+                .type(MOCK_ACCESS_POLICY_TYPE)
+                .description(MOCK_ACCESS_POLICY_DESCRIPTION)
+                .policy(MOCK_ACCESS_POLICY_DOCUMENT.toString())
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+
+        assertThrows(CfnServiceLimitExceededException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).createAccessPolicy(any(CreateAccessPolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_InternalServerException_Fail() {
+        when(openSearchServerlessClient.createAccessPolicy(any(CreateAccessPolicyRequest.class)))
+                .thenThrow(InternalServerException.builder().build());
+
+        final CreateHandler handler = new CreateHandler(openSearchServerlessClient);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_ACCESS_POLICY_NAME)
+                .type(MOCK_ACCESS_POLICY_TYPE)
+                .description(MOCK_ACCESS_POLICY_DESCRIPTION)
+                .policy(MOCK_ACCESS_POLICY_DOCUMENT.toString())
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+
+        assertThrows(CfnServiceInternalErrorException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).createAccessPolicy(any(CreateAccessPolicyRequest.class));
     }
 }

--- a/aws-opensearchserverless-accesspolicy/src/test/java/software/amazon/opensearchserverless/accesspolicy/UpdateHandlerTest.java
+++ b/aws-opensearchserverless-accesspolicy/src/test/java/software/amazon/opensearchserverless/accesspolicy/UpdateHandlerTest.java
@@ -1,8 +1,28 @@
 package software.amazon.opensearchserverless.accesspolicy;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.document.Document;
 import software.amazon.awssdk.services.opensearchserverless.OpenSearchServerlessClient;
-import software.amazon.awssdk.services.opensearchserverless.model.*;
+import software.amazon.awssdk.services.opensearchserverless.model.AccessPolicyDetail;
+import software.amazon.awssdk.services.opensearchserverless.model.AccessPolicyType;
+import software.amazon.awssdk.services.opensearchserverless.model.ConflictException;
+import software.amazon.awssdk.services.opensearchserverless.model.GetAccessPolicyRequest;
+import software.amazon.awssdk.services.opensearchserverless.model.GetAccessPolicyResponse;
+import software.amazon.awssdk.services.opensearchserverless.model.InternalServerException;
+import software.amazon.awssdk.services.opensearchserverless.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.opensearchserverless.model.ServiceQuotaExceededException;
+import software.amazon.awssdk.services.opensearchserverless.model.UpdateAccessPolicyRequest;
+import software.amazon.awssdk.services.opensearchserverless.model.UpdateAccessPolicyResponse;
+import software.amazon.awssdk.services.opensearchserverless.model.ValidationException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
+import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
+import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -11,12 +31,8 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.time.Duration;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -104,5 +120,175 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_ResourceNotFoundException_Fail() {
+        when(openSearchServerlessClient.updateAccessPolicy(any(UpdateAccessPolicyRequest.class)))
+                .thenThrow(ResourceNotFoundException.builder().build());
+
+        final UpdateHandler handler = new UpdateHandler(openSearchServerlessClient);
+
+        final GetAccessPolicyResponse getAccessPolicyResponse =
+                GetAccessPolicyResponse.builder()
+                        .accessPolicyDetail(
+                                AccessPolicyDetail.builder()
+                                        .name(MOCK_ACCESS_POLICY_NAME)
+                                        .type(MOCK_ACCESS_POLICY_TYPE)
+                                        .description(MOCK_ACCESS_POLICY_DESCRIPTION)
+                                        .policy(MOCK_ACCESS_POLICY_DOCUMENT)
+                                        .policyVersion(MOCK_ACCESS_POLICY_VERSION)
+                                        .build()
+                        ).build();
+        when(openSearchServerlessClient.getAccessPolicy(any(GetAccessPolicyRequest.class))).thenReturn(getAccessPolicyResponse);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_ACCESS_POLICY_NAME)
+                .type(MOCK_ACCESS_POLICY_TYPE)
+                .description(MOCK_ACCESS_POLICY_DESCRIPTION)
+                .policy(MOCK_ACCESS_POLICY_DOCUMENT.toString())
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+
+        assertThrows(CfnNotFoundException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).updateAccessPolicy(any(UpdateAccessPolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_ValidationException_Fail() {
+        when(openSearchServerlessClient.updateAccessPolicy(any(UpdateAccessPolicyRequest.class)))
+                .thenThrow(ValidationException.builder().build());
+
+        final UpdateHandler handler = new UpdateHandler(openSearchServerlessClient);
+
+        final GetAccessPolicyResponse getAccessPolicyResponse =
+                GetAccessPolicyResponse.builder()
+                        .accessPolicyDetail(
+                                AccessPolicyDetail.builder()
+                                        .name(MOCK_ACCESS_POLICY_NAME)
+                                        .type(MOCK_ACCESS_POLICY_TYPE)
+                                        .description(MOCK_ACCESS_POLICY_DESCRIPTION)
+                                        .policy(MOCK_ACCESS_POLICY_DOCUMENT)
+                                        .policyVersion(MOCK_ACCESS_POLICY_VERSION)
+                                        .build()
+                        ).build();
+        when(openSearchServerlessClient.getAccessPolicy(any(GetAccessPolicyRequest.class))).thenReturn(getAccessPolicyResponse);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_ACCESS_POLICY_NAME)
+                .type(MOCK_ACCESS_POLICY_TYPE)
+                .description(MOCK_ACCESS_POLICY_DESCRIPTION)
+                .policy(MOCK_ACCESS_POLICY_DOCUMENT.toString())
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+
+        assertThrows(CfnInvalidRequestException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).updateAccessPolicy(any(UpdateAccessPolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_ConflictException_Fail() {
+        when(openSearchServerlessClient.updateAccessPolicy(any(UpdateAccessPolicyRequest.class)))
+                .thenThrow(ConflictException.builder().build());
+
+        final UpdateHandler handler = new UpdateHandler(openSearchServerlessClient);
+
+        final GetAccessPolicyResponse getAccessPolicyResponse =
+                GetAccessPolicyResponse.builder()
+                        .accessPolicyDetail(
+                                AccessPolicyDetail.builder()
+                                        .name(MOCK_ACCESS_POLICY_NAME)
+                                        .type(MOCK_ACCESS_POLICY_TYPE)
+                                        .description(MOCK_ACCESS_POLICY_DESCRIPTION)
+                                        .policy(MOCK_ACCESS_POLICY_DOCUMENT)
+                                        .policyVersion(MOCK_ACCESS_POLICY_VERSION)
+                                        .build()
+                        ).build();
+        when(openSearchServerlessClient.getAccessPolicy(any(GetAccessPolicyRequest.class))).thenReturn(getAccessPolicyResponse);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_ACCESS_POLICY_NAME)
+                .type(MOCK_ACCESS_POLICY_TYPE)
+                .description(MOCK_ACCESS_POLICY_DESCRIPTION)
+                .policy(MOCK_ACCESS_POLICY_DOCUMENT.toString())
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+
+        assertThrows(CfnResourceConflictException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).updateAccessPolicy(any(UpdateAccessPolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_ServiceQuotaExceededException_Fail() {
+        when(openSearchServerlessClient.updateAccessPolicy(any(UpdateAccessPolicyRequest.class)))
+                .thenThrow(ServiceQuotaExceededException.builder().build());
+
+        final UpdateHandler handler = new UpdateHandler(openSearchServerlessClient);
+
+        final GetAccessPolicyResponse getAccessPolicyResponse =
+                GetAccessPolicyResponse.builder()
+                        .accessPolicyDetail(
+                                AccessPolicyDetail.builder()
+                                        .name(MOCK_ACCESS_POLICY_NAME)
+                                        .type(MOCK_ACCESS_POLICY_TYPE)
+                                        .description(MOCK_ACCESS_POLICY_DESCRIPTION)
+                                        .policy(MOCK_ACCESS_POLICY_DOCUMENT)
+                                        .policyVersion(MOCK_ACCESS_POLICY_VERSION)
+                                        .build()
+                        ).build();
+        when(openSearchServerlessClient.getAccessPolicy(any(GetAccessPolicyRequest.class))).thenReturn(getAccessPolicyResponse);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_ACCESS_POLICY_NAME)
+                .type(MOCK_ACCESS_POLICY_TYPE)
+                .description(MOCK_ACCESS_POLICY_DESCRIPTION)
+                .policy(MOCK_ACCESS_POLICY_DOCUMENT.toString())
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+
+        assertThrows(CfnServiceLimitExceededException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).updateAccessPolicy(any(UpdateAccessPolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_InternalServerException_Fail() {
+        when(openSearchServerlessClient.updateAccessPolicy(any(UpdateAccessPolicyRequest.class)))
+                .thenThrow(InternalServerException.builder().build());
+
+        final UpdateHandler handler = new UpdateHandler(openSearchServerlessClient);
+
+        final GetAccessPolicyResponse getAccessPolicyResponse =
+                GetAccessPolicyResponse.builder()
+                        .accessPolicyDetail(
+                                AccessPolicyDetail.builder()
+                                        .name(MOCK_ACCESS_POLICY_NAME)
+                                        .type(MOCK_ACCESS_POLICY_TYPE)
+                                        .description(MOCK_ACCESS_POLICY_DESCRIPTION)
+                                        .policy(MOCK_ACCESS_POLICY_DOCUMENT)
+                                        .policyVersion(MOCK_ACCESS_POLICY_VERSION)
+                                        .build()
+                        ).build();
+        when(openSearchServerlessClient.getAccessPolicy(any(GetAccessPolicyRequest.class))).thenReturn(getAccessPolicyResponse);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_ACCESS_POLICY_NAME)
+                .type(MOCK_ACCESS_POLICY_TYPE)
+                .description(MOCK_ACCESS_POLICY_DESCRIPTION)
+                .policy(MOCK_ACCESS_POLICY_DOCUMENT.toString())
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+
+        assertThrows(CfnServiceInternalErrorException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).updateAccessPolicy(any(UpdateAccessPolicyRequest.class));
     }
 }

--- a/aws-opensearchserverless-lifecyclepolicy/src/main/java/software/amazon/opensearchserverless/lifecyclepolicy/CreateHandler.java
+++ b/aws-opensearchserverless-lifecyclepolicy/src/main/java/software/amazon/opensearchserverless/lifecyclepolicy/CreateHandler.java
@@ -62,8 +62,12 @@ public class CreateHandler extends BaseHandlerStd {
             logger.log(String.format("Sending create lifecycle policy request: %s", createLifecyclePolicyRequest));
             createLifecyclePolicyResponse = proxyClient.injectCredentialsAndInvokeV2(createLifecyclePolicyRequest, proxyClient.client()::createLifecyclePolicy);
         } catch (ConflictException e) {
-            throw new CfnAlreadyExistsException(ResourceModel.TYPE_NAME, String.format("Name:%s, Type:%s",
-                createLifecyclePolicyRequest.name(), createLifecyclePolicyRequest.typeAsString()), e);
+            if (e.getMessage().contains("already exists")) {
+                throw new CfnAlreadyExistsException(ResourceModel.TYPE_NAME, String.format("Name:%s, Type:%s",
+                        createLifecyclePolicyRequest.name(), createLifecyclePolicyRequest.typeAsString()), e);
+            } else {
+                throw new CfnInvalidRequestException(createLifecyclePolicyRequest.toString() + ", " + e.getMessage(), e);
+            }
         } catch (ValidationException e) {
             throw new CfnInvalidRequestException(createLifecyclePolicyRequest.toString() + ", " + e.getMessage(), e);
         } catch (ServiceQuotaExceededException e) {

--- a/aws-opensearchserverless-lifecyclepolicy/src/main/java/software/amazon/opensearchserverless/lifecyclepolicy/Translator.java
+++ b/aws-opensearchserverless-lifecyclepolicy/src/main/java/software/amazon/opensearchserverless/lifecyclepolicy/Translator.java
@@ -139,9 +139,7 @@ public class Translator {
     }
 
     private static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {
-        return Optional.ofNullable(collection)
-            .map(Collection::stream)
-            .orElseGet(Stream::empty);
+        return Optional.ofNullable(collection).stream().flatMap(Collection::stream);
     }
 
     private static ResourceModel translateLifecyclePolicySummaryFromSDK(LifecyclePolicySummary lifecyclePolicySummary) {
@@ -169,5 +167,14 @@ public class Translator {
             .description(lifecyclePolicyDetail.description())
             .policy(lifecyclePolicyDetail.policy().toString())
             .build();
+    }
+
+    static String getResourceIdentifierForUpdateLifecyclePolicyRequest(
+        final UpdateLifecyclePolicyRequest updateLifecyclePolicyRequest) {
+        return String.format("%s|%s", updateLifecyclePolicyRequest.typeAsString(), updateLifecyclePolicyRequest.name());
+    }
+
+    static String getResourceIdentifier(final LifecyclePolicyIdentifier lifecyclePolicyIdentifier) {
+        return String.format("%s|%s", lifecyclePolicyIdentifier.typeAsString(), lifecyclePolicyIdentifier.name());
     }
 }

--- a/aws-opensearchserverless-lifecyclepolicy/src/main/java/software/amazon/opensearchserverless/lifecyclepolicy/UpdateHandler.java
+++ b/aws-opensearchserverless-lifecyclepolicy/src/main/java/software/amazon/opensearchserverless/lifecyclepolicy/UpdateHandler.java
@@ -12,10 +12,10 @@ import software.amazon.awssdk.services.opensearchserverless.model.ServiceQuotaEx
 import software.amazon.awssdk.services.opensearchserverless.model.UpdateLifecyclePolicyRequest;
 import software.amazon.awssdk.services.opensearchserverless.model.UpdateLifecyclePolicyResponse;
 import software.amazon.awssdk.services.opensearchserverless.model.ValidationException;
-import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
 import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -109,8 +109,7 @@ public class UpdateHandler extends BaseHandlerStd {
         try {
             updateLifecyclePolicyResponse = proxyClient.injectCredentialsAndInvokeV2(updateLifecyclePolicyRequest, proxyClient.client()::updateLifecyclePolicy);
         } catch (ConflictException e) {
-            throw new CfnAlreadyExistsException(ResourceModel.TYPE_NAME, String.format("Name:%s, Type:%s",
-                updateLifecyclePolicyRequest.name(), updateLifecyclePolicyRequest.typeAsString()), e);
+            throw new CfnResourceConflictException(ResourceModel.TYPE_NAME, updateLifecyclePolicyRequest.name(), e.getMessage(), e);
         } catch (ResourceNotFoundException e) {
             throw new CfnNotFoundException(e);
         } catch (ValidationException e) {

--- a/aws-opensearchserverless-lifecyclepolicy/src/test/java/software/amazon/opensearchserverless/lifecyclepolicy/UpdateHandlerTest.java
+++ b/aws-opensearchserverless-lifecyclepolicy/src/test/java/software/amazon/opensearchserverless/lifecyclepolicy/UpdateHandlerTest.java
@@ -7,12 +7,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.document.Document;
 import software.amazon.awssdk.services.opensearchserverless.OpenSearchServerlessClient;
+import software.amazon.awssdk.services.opensearchserverless.model.ConflictException;
+import software.amazon.awssdk.services.opensearchserverless.model.InternalServerException;
 import software.amazon.awssdk.services.opensearchserverless.model.LifecyclePolicyDetail;
 import software.amazon.awssdk.services.opensearchserverless.model.LifecyclePolicyType;
 import software.amazon.awssdk.services.opensearchserverless.model.BatchGetLifecyclePolicyRequest;
 import software.amazon.awssdk.services.opensearchserverless.model.BatchGetLifecyclePolicyResponse;
+import software.amazon.awssdk.services.opensearchserverless.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.opensearchserverless.model.ServiceQuotaExceededException;
 import software.amazon.awssdk.services.opensearchserverless.model.UpdateLifecyclePolicyRequest;
 import software.amazon.awssdk.services.opensearchserverless.model.UpdateLifecyclePolicyResponse;
+import software.amazon.awssdk.services.opensearchserverless.model.ValidationException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
+import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
+import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -22,6 +32,7 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -109,5 +120,175 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_ConflictException_Fail() {
+        when(openSearchServerlessClient.updateLifecyclePolicy(any(UpdateLifecyclePolicyRequest.class)))
+                .thenThrow(ConflictException.builder().build());
+
+        final UpdateHandler handler = new UpdateHandler(openSearchServerlessClient);
+
+        final BatchGetLifecyclePolicyResponse batchGetLifecyclePolicyResponse =
+                BatchGetLifecyclePolicyResponse.builder()
+                        .lifecyclePolicyDetails(
+                                LifecyclePolicyDetail.builder()
+                                        .name(MOCK_LIFECYCLE_POLICY_NAME)
+                                        .type(MOCK_LIFECYCLE_POLICY_TYPE)
+                                        .description(MOCK_LIFECYCLE_POLICY_DESCRIPTION)
+                                        .policy(MOCK_LIFECYCLE_POLICY_DOCUMENT)
+                                        .policyVersion(MOCK_LIFECYCLE_POLICY_VERSION)
+                                        .build()
+                        ).build();
+        when(openSearchServerlessClient.batchGetLifecyclePolicy(any(BatchGetLifecyclePolicyRequest.class))).thenReturn(batchGetLifecyclePolicyResponse);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_LIFECYCLE_POLICY_NAME)
+                .type(MOCK_LIFECYCLE_POLICY_TYPE)
+                .description(MOCK_LIFECYCLE_POLICY_DESCRIPTION)
+                .policy(MOCK_LIFECYCLE_POLICY_DOCUMENT.toString())
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+
+        assertThrows(CfnResourceConflictException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).updateLifecyclePolicy(any(UpdateLifecyclePolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_ResourceNotFoundException_Fail() {
+        when(openSearchServerlessClient.updateLifecyclePolicy(any(UpdateLifecyclePolicyRequest.class)))
+                .thenThrow(ResourceNotFoundException.builder().build());
+
+        final UpdateHandler handler = new UpdateHandler(openSearchServerlessClient);
+
+        final BatchGetLifecyclePolicyResponse batchGetLifecyclePolicyResponse =
+                BatchGetLifecyclePolicyResponse.builder()
+                        .lifecyclePolicyDetails(
+                                LifecyclePolicyDetail.builder()
+                                        .name(MOCK_LIFECYCLE_POLICY_NAME)
+                                        .type(MOCK_LIFECYCLE_POLICY_TYPE)
+                                        .description(MOCK_LIFECYCLE_POLICY_DESCRIPTION)
+                                        .policy(MOCK_LIFECYCLE_POLICY_DOCUMENT)
+                                        .policyVersion(MOCK_LIFECYCLE_POLICY_VERSION)
+                                        .build()
+                        ).build();
+        when(openSearchServerlessClient.batchGetLifecyclePolicy(any(BatchGetLifecyclePolicyRequest.class))).thenReturn(batchGetLifecyclePolicyResponse);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_LIFECYCLE_POLICY_NAME)
+                .type(MOCK_LIFECYCLE_POLICY_TYPE)
+                .description(MOCK_LIFECYCLE_POLICY_DESCRIPTION)
+                .policy(MOCK_LIFECYCLE_POLICY_DOCUMENT.toString())
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+
+        assertThrows(CfnNotFoundException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).updateLifecyclePolicy(any(UpdateLifecyclePolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_ValidationException_Fail() {
+        when(openSearchServerlessClient.updateLifecyclePolicy(any(UpdateLifecyclePolicyRequest.class)))
+                .thenThrow(ValidationException.builder().build());
+
+        final UpdateHandler handler = new UpdateHandler(openSearchServerlessClient);
+
+        final BatchGetLifecyclePolicyResponse batchGetLifecyclePolicyResponse =
+                BatchGetLifecyclePolicyResponse.builder()
+                        .lifecyclePolicyDetails(
+                                LifecyclePolicyDetail.builder()
+                                        .name(MOCK_LIFECYCLE_POLICY_NAME)
+                                        .type(MOCK_LIFECYCLE_POLICY_TYPE)
+                                        .description(MOCK_LIFECYCLE_POLICY_DESCRIPTION)
+                                        .policy(MOCK_LIFECYCLE_POLICY_DOCUMENT)
+                                        .policyVersion(MOCK_LIFECYCLE_POLICY_VERSION)
+                                        .build()
+                        ).build();
+        when(openSearchServerlessClient.batchGetLifecyclePolicy(any(BatchGetLifecyclePolicyRequest.class))).thenReturn(batchGetLifecyclePolicyResponse);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_LIFECYCLE_POLICY_NAME)
+                .type(MOCK_LIFECYCLE_POLICY_TYPE)
+                .description(MOCK_LIFECYCLE_POLICY_DESCRIPTION)
+                .policy(MOCK_LIFECYCLE_POLICY_DOCUMENT.toString())
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+
+        assertThrows(CfnInvalidRequestException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).updateLifecyclePolicy(any(UpdateLifecyclePolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_ServiceQuotaExceededException_Fail() {
+        when(openSearchServerlessClient.updateLifecyclePolicy(any(UpdateLifecyclePolicyRequest.class)))
+                .thenThrow(ServiceQuotaExceededException.builder().build());
+
+        final UpdateHandler handler = new UpdateHandler(openSearchServerlessClient);
+
+        final BatchGetLifecyclePolicyResponse batchGetLifecyclePolicyResponse =
+                BatchGetLifecyclePolicyResponse.builder()
+                        .lifecyclePolicyDetails(
+                                LifecyclePolicyDetail.builder()
+                                        .name(MOCK_LIFECYCLE_POLICY_NAME)
+                                        .type(MOCK_LIFECYCLE_POLICY_TYPE)
+                                        .description(MOCK_LIFECYCLE_POLICY_DESCRIPTION)
+                                        .policy(MOCK_LIFECYCLE_POLICY_DOCUMENT)
+                                        .policyVersion(MOCK_LIFECYCLE_POLICY_VERSION)
+                                        .build()
+                        ).build();
+        when(openSearchServerlessClient.batchGetLifecyclePolicy(any(BatchGetLifecyclePolicyRequest.class))).thenReturn(batchGetLifecyclePolicyResponse);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_LIFECYCLE_POLICY_NAME)
+                .type(MOCK_LIFECYCLE_POLICY_TYPE)
+                .description(MOCK_LIFECYCLE_POLICY_DESCRIPTION)
+                .policy(MOCK_LIFECYCLE_POLICY_DOCUMENT.toString())
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+
+        assertThrows(CfnServiceLimitExceededException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).updateLifecyclePolicy(any(UpdateLifecyclePolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_InternalServerException_Fail() {
+        when(openSearchServerlessClient.updateLifecyclePolicy(any(UpdateLifecyclePolicyRequest.class)))
+                .thenThrow(InternalServerException.builder().build());
+
+        final UpdateHandler handler = new UpdateHandler(openSearchServerlessClient);
+
+        final BatchGetLifecyclePolicyResponse batchGetLifecyclePolicyResponse =
+                BatchGetLifecyclePolicyResponse.builder()
+                        .lifecyclePolicyDetails(
+                                LifecyclePolicyDetail.builder()
+                                        .name(MOCK_LIFECYCLE_POLICY_NAME)
+                                        .type(MOCK_LIFECYCLE_POLICY_TYPE)
+                                        .description(MOCK_LIFECYCLE_POLICY_DESCRIPTION)
+                                        .policy(MOCK_LIFECYCLE_POLICY_DOCUMENT)
+                                        .policyVersion(MOCK_LIFECYCLE_POLICY_VERSION)
+                                        .build()
+                        ).build();
+        when(openSearchServerlessClient.batchGetLifecyclePolicy(any(BatchGetLifecyclePolicyRequest.class))).thenReturn(batchGetLifecyclePolicyResponse);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_LIFECYCLE_POLICY_NAME)
+                .type(MOCK_LIFECYCLE_POLICY_TYPE)
+                .description(MOCK_LIFECYCLE_POLICY_DESCRIPTION)
+                .policy(MOCK_LIFECYCLE_POLICY_DOCUMENT.toString())
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+
+        assertThrows(CfnServiceInternalErrorException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).updateLifecyclePolicy(any(UpdateLifecyclePolicyRequest.class));
     }
 }

--- a/aws-opensearchserverless-securityconfig/src/main/java/software/amazon/opensearchserverless/securityconfig/CreateHandler.java
+++ b/aws-opensearchserverless-securityconfig/src/main/java/software/amazon/opensearchserverless/securityconfig/CreateHandler.java
@@ -5,10 +5,12 @@ import software.amazon.awssdk.services.opensearchserverless.model.ConflictExcept
 import software.amazon.awssdk.services.opensearchserverless.model.CreateSecurityConfigRequest;
 import software.amazon.awssdk.services.opensearchserverless.model.CreateSecurityConfigResponse;
 import software.amazon.awssdk.services.opensearchserverless.model.InternalServerException;
+import software.amazon.awssdk.services.opensearchserverless.model.ServiceQuotaExceededException;
 import software.amazon.awssdk.services.opensearchserverless.model.ValidationException;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
+import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -64,10 +66,16 @@ public class CreateHandler extends BaseHandlerStd {
             createSecurityConfigResponse =
                     proxyClient.injectCredentialsAndInvokeV2(createSecurityConfigRequest, proxyClient.client()::createSecurityConfig);
         } catch (ConflictException e) {
-            throw new CfnAlreadyExistsException(ResourceModel.TYPE_NAME, String.format("Name:%s, Type:%s",
-                    createSecurityConfigRequest.name(), createSecurityConfigRequest.typeAsString()), e);
+            if (e.getMessage() != null && e.getMessage().contains("already exists")) {
+                throw new CfnAlreadyExistsException(ResourceModel.TYPE_NAME, String.format("Name:%s, Type:%s",
+                        createSecurityConfigRequest.name(), createSecurityConfigRequest.typeAsString()), e);
+            } else {
+                throw new CfnInvalidRequestException(createSecurityConfigRequest.toString() + ", " + e.getMessage(), e);
+            }
         } catch (ValidationException e) {
             throw new CfnInvalidRequestException(createSecurityConfigRequest.toString() + ", " + e.getMessage(), e);
+        } catch (ServiceQuotaExceededException e) {
+            throw new CfnServiceLimitExceededException(e);
         } catch (InternalServerException e) {
             throw new CfnServiceInternalErrorException("CreateSecurityConfig", e);
         }

--- a/aws-opensearchserverless-securityconfig/src/main/java/software/amazon/opensearchserverless/securityconfig/UpdateHandler.java
+++ b/aws-opensearchserverless-securityconfig/src/main/java/software/amazon/opensearchserverless/securityconfig/UpdateHandler.java
@@ -100,6 +100,8 @@ public class UpdateHandler extends BaseHandlerStd {
         } catch (ConflictException e) {
             throw new CfnResourceConflictException(ResourceModel.TYPE_NAME, updateSecurityConfigRequest.id(),
                     e.getMessage(), e);
+        } catch (ServiceQuotaExceededException e) {
+            throw new CfnServiceLimitExceededException(e);
         } catch (InternalServerException e) {
             throw new CfnServiceInternalErrorException("UpdateSecurityConfig", e);
         }

--- a/aws-opensearchserverless-securitypolicy/src/main/java/software/amazon/opensearchserverless/securitypolicy/Translator.java
+++ b/aws-opensearchserverless-securitypolicy/src/main/java/software/amazon/opensearchserverless/securitypolicy/Translator.java
@@ -125,9 +125,7 @@ public class Translator {
     }
 
     private static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {
-        return Optional.ofNullable(collection)
-            .map(Collection::stream)
-            .orElseGet(Stream::empty);
+        return Optional.ofNullable(collection).stream().flatMap(Collection::stream);
     }
 
     /**
@@ -145,5 +143,16 @@ public class Translator {
             .description(securityPolicyDetail.description())
             .policy(securityPolicyDetail.policy().toString())
             .build();
+    }
+
+    static String getResourceIdentifierForUpdateSecurityPolicyRequest(
+        final UpdateSecurityPolicyRequest updateSecurityPolicyRequest) {
+        return String.format("%s|%s",
+            updateSecurityPolicyRequest.typeAsString(), updateSecurityPolicyRequest.name());
+    }
+
+    static String getResourceIdentifierForGetSecurityPolicyRequest(final GetSecurityPolicyRequest getSecurityPolicyRequest) {
+        return String.format("%s|%s",
+            getSecurityPolicyRequest.typeAsString(), getSecurityPolicyRequest.name());
     }
 }

--- a/aws-opensearchserverless-securitypolicy/src/main/java/software/amazon/opensearchserverless/securitypolicy/UpdateHandler.java
+++ b/aws-opensearchserverless-securitypolicy/src/main/java/software/amazon/opensearchserverless/securitypolicy/UpdateHandler.java
@@ -23,6 +23,9 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import static software.amazon.opensearchserverless.securitypolicy.Translator.getResourceIdentifierForGetSecurityPolicyRequest;
+import static software.amazon.opensearchserverless.securitypolicy.Translator.getResourceIdentifierForUpdateSecurityPolicyRequest;
+
 public class UpdateHandler extends BaseHandlerStd {
 
     public UpdateHandler() {
@@ -110,13 +113,16 @@ public class UpdateHandler extends BaseHandlerStd {
             updateSecurityPolicyResponse = proxyClient.injectCredentialsAndInvokeV2(updateSecurityPolicyRequest,
                 proxyClient.client()::updateSecurityPolicy);
         } catch (ResourceNotFoundException e) {
-            throw new CfnNotFoundException(ResourceModel.TYPE_NAME, String.format("Name:%s, Type:%s",
-                updateSecurityPolicyRequest.name(), updateSecurityPolicyRequest.typeAsString()), e);
+            throw new CfnNotFoundException(ResourceModel.TYPE_NAME,
+                getResourceIdentifierForUpdateSecurityPolicyRequest(updateSecurityPolicyRequest),
+                e);
         } catch (ValidationException e) {
             throw new CfnInvalidRequestException(updateSecurityPolicyRequest.toString() + ", " + e.getMessage(), e);
         } catch (ConflictException e) {
-            throw new CfnResourceConflictException(ResourceModel.TYPE_NAME, updateSecurityPolicyRequest.name(),
-                e.getMessage(), e);
+            throw new CfnResourceConflictException(ResourceModel.TYPE_NAME,
+                getResourceIdentifierForUpdateSecurityPolicyRequest(updateSecurityPolicyRequest),
+                e.getMessage(),
+                e);
         } catch (ServiceQuotaExceededException e) {
             throw new CfnServiceLimitExceededException(e);
         } catch (InternalServerException e) {
@@ -138,8 +144,9 @@ public class UpdateHandler extends BaseHandlerStd {
             getSecurityPolicyResponse = proxyClient.injectCredentialsAndInvokeV2(getSecurityPolicyRequest,
                 proxyClient.client()::getSecurityPolicy);
         } catch (ResourceNotFoundException e) {
-            throw new CfnNotFoundException(ResourceModel.TYPE_NAME, String.format("Name:%s, Type:%s",
-                getSecurityPolicyRequest.name(), getSecurityPolicyRequest.typeAsString()), e);
+            throw new CfnNotFoundException(ResourceModel.TYPE_NAME,
+                getResourceIdentifierForGetSecurityPolicyRequest(getSecurityPolicyRequest),
+                e);
         } catch (ValidationException e) {
             throw new CfnInvalidRequestException(getSecurityPolicyRequest.toString() + ", " + e.getMessage(), e);
         } catch (InternalServerException e) {

--- a/aws-opensearchserverless-securitypolicy/src/main/java/software/amazon/opensearchserverless/securitypolicy/UpdateHandler.java
+++ b/aws-opensearchserverless-securitypolicy/src/main/java/software/amazon/opensearchserverless/securitypolicy/UpdateHandler.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.services.opensearchserverless.model.GetSecurityPol
 import software.amazon.awssdk.services.opensearchserverless.model.GetSecurityPolicyResponse;
 import software.amazon.awssdk.services.opensearchserverless.model.InternalServerException;
 import software.amazon.awssdk.services.opensearchserverless.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.opensearchserverless.model.ServiceQuotaExceededException;
 import software.amazon.awssdk.services.opensearchserverless.model.UpdateSecurityPolicyRequest;
 import software.amazon.awssdk.services.opensearchserverless.model.UpdateSecurityPolicyResponse;
 import software.amazon.awssdk.services.opensearchserverless.model.ValidationException;
@@ -14,6 +15,7 @@ import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
+import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -115,6 +117,8 @@ public class UpdateHandler extends BaseHandlerStd {
         } catch (ConflictException e) {
             throw new CfnResourceConflictException(ResourceModel.TYPE_NAME, updateSecurityPolicyRequest.name(),
                 e.getMessage(), e);
+        } catch (ServiceQuotaExceededException e) {
+            throw new CfnServiceLimitExceededException(e);
         } catch (InternalServerException e) {
             throw new CfnServiceInternalErrorException("UpdateSecurityPolicy", e);
         }

--- a/aws-opensearchserverless-securitypolicy/src/test/java/software/amazon/opensearchserverless/securitypolicy/UpdateHandlerTest.java
+++ b/aws-opensearchserverless-securitypolicy/src/test/java/software/amazon/opensearchserverless/securitypolicy/UpdateHandlerTest.java
@@ -2,11 +2,19 @@ package software.amazon.opensearchserverless.securitypolicy;
 
 import software.amazon.awssdk.core.document.Document;
 import software.amazon.awssdk.services.opensearchserverless.OpenSearchServerlessClient;
+import software.amazon.awssdk.services.opensearchserverless.model.ConflictException;
 import software.amazon.awssdk.services.opensearchserverless.model.GetSecurityPolicyRequest;
 import software.amazon.awssdk.services.opensearchserverless.model.GetSecurityPolicyResponse;
+import software.amazon.awssdk.services.opensearchserverless.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.opensearchserverless.model.SecurityPolicyDetail;
+import software.amazon.awssdk.services.opensearchserverless.model.ServiceQuotaExceededException;
 import software.amazon.awssdk.services.opensearchserverless.model.UpdateSecurityPolicyRequest;
 import software.amazon.awssdk.services.opensearchserverless.model.UpdateSecurityPolicyResponse;
+import software.amazon.awssdk.services.opensearchserverless.model.ValidationException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
+import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -23,7 +31,10 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest extends AbstractTestBase {
@@ -49,7 +60,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
     @AfterEach
     public void tear_down() {
-        Mockito.verify(openSearchServerlessClient, Mockito.atLeastOnce()).serviceName();
+        verify(openSearchServerlessClient, Mockito.atLeastOnce()).serviceName();
         Mockito.verifyNoMoreInteractions(openSearchServerlessClient);
     }
 
@@ -66,7 +77,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
                     .build()
             ).build();
 
-        Mockito.when(proxyClient.client().updateSecurityPolicy(any(UpdateSecurityPolicyRequest.class)))
+        when(openSearchServerlessClient.updateSecurityPolicy(any(UpdateSecurityPolicyRequest.class)))
             .thenReturn(updateSecurityPolicyResponse);
 
         final GetSecurityPolicyResponse getSecurityPolicyResponse = GetSecurityPolicyResponse.builder()
@@ -80,7 +91,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
                     .build()
             ).build();
 
-        Mockito.when(proxyClient.client().getSecurityPolicy(any(GetSecurityPolicyRequest.class)))
+        when(openSearchServerlessClient.getSecurityPolicy(any(GetSecurityPolicyRequest.class)))
             .thenReturn(getSecurityPolicyResponse);
 
         final ResourceModel model = ResourceModel.builder()
@@ -105,6 +116,150 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
-        Mockito.verify(proxyClient.client()).updateSecurityPolicy(any(UpdateSecurityPolicyRequest.class));
+        verify(openSearchServerlessClient).updateSecurityPolicy(any(UpdateSecurityPolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_ResourceNotFoundException_Fail() {
+        when(openSearchServerlessClient.updateSecurityPolicy(any(UpdateSecurityPolicyRequest.class)))
+                .thenThrow(ResourceNotFoundException.builder().build());
+
+        final GetSecurityPolicyResponse getSecurityPolicyResponse = GetSecurityPolicyResponse.builder()
+                .securityPolicyDetail(
+                        SecurityPolicyDetail.builder()
+                                .name(MOCK_POLICY_NAME)
+                                .type(MOCK_POLICY_TYPE)
+                                .policyVersion(MOCK_POLICY_VERSION)
+                                .description(MOCK_POLICY_DESCRIPTION)
+                                .policy(MOCK_POLICY_DOCUMENT)
+                                .build()
+                ).build();
+
+        when(openSearchServerlessClient.getSecurityPolicy(any(GetSecurityPolicyRequest.class)))
+                .thenReturn(getSecurityPolicyResponse);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_POLICY_NAME)
+                .type(MOCK_POLICY_TYPE)
+                .description(MOCK_POLICY_DESCRIPTION)
+                .policy(MOCK_POLICY_DOCUMENT.toString())
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        assertThrows(CfnNotFoundException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).updateSecurityPolicy(any(UpdateSecurityPolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_ValidationException_Fail() {
+        when(openSearchServerlessClient.updateSecurityPolicy(any(UpdateSecurityPolicyRequest.class)))
+                .thenThrow(ValidationException.builder().build());
+
+        final GetSecurityPolicyResponse getSecurityPolicyResponse = GetSecurityPolicyResponse.builder()
+                .securityPolicyDetail(
+                        SecurityPolicyDetail.builder()
+                                .name(MOCK_POLICY_NAME)
+                                .type(MOCK_POLICY_TYPE)
+                                .policyVersion(MOCK_POLICY_VERSION)
+                                .description(MOCK_POLICY_DESCRIPTION)
+                                .policy(MOCK_POLICY_DOCUMENT)
+                                .build()
+                ).build();
+
+        when(openSearchServerlessClient.getSecurityPolicy(any(GetSecurityPolicyRequest.class)))
+                .thenReturn(getSecurityPolicyResponse);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_POLICY_NAME)
+                .type(MOCK_POLICY_TYPE)
+                .description(MOCK_POLICY_DESCRIPTION)
+                .policy(MOCK_POLICY_DOCUMENT.toString())
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        assertThrows(CfnInvalidRequestException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).updateSecurityPolicy(any(UpdateSecurityPolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_ConflictException_Fail() {
+        when(openSearchServerlessClient.updateSecurityPolicy(any(UpdateSecurityPolicyRequest.class)))
+                .thenThrow(ConflictException.builder().build());
+
+        final GetSecurityPolicyResponse getSecurityPolicyResponse = GetSecurityPolicyResponse.builder()
+                .securityPolicyDetail(
+                        SecurityPolicyDetail.builder()
+                                .name(MOCK_POLICY_NAME)
+                                .type(MOCK_POLICY_TYPE)
+                                .policyVersion(MOCK_POLICY_VERSION)
+                                .description(MOCK_POLICY_DESCRIPTION)
+                                .policy(MOCK_POLICY_DOCUMENT)
+                                .build()
+                ).build();
+
+        when(openSearchServerlessClient.getSecurityPolicy(any(GetSecurityPolicyRequest.class)))
+                .thenReturn(getSecurityPolicyResponse);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_POLICY_NAME)
+                .type(MOCK_POLICY_TYPE)
+                .description(MOCK_POLICY_DESCRIPTION)
+                .policy(MOCK_POLICY_DOCUMENT.toString())
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        assertThrows(CfnResourceConflictException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).updateSecurityPolicy(any(UpdateSecurityPolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_ServiceQuotaExceededException_Fail() {
+        when(openSearchServerlessClient.updateSecurityPolicy(any(UpdateSecurityPolicyRequest.class)))
+                .thenThrow(ServiceQuotaExceededException.builder().build());
+
+        final GetSecurityPolicyResponse getSecurityPolicyResponse = GetSecurityPolicyResponse.builder()
+                .securityPolicyDetail(
+                        SecurityPolicyDetail.builder()
+                                .name(MOCK_POLICY_NAME)
+                                .type(MOCK_POLICY_TYPE)
+                                .policyVersion(MOCK_POLICY_VERSION)
+                                .description(MOCK_POLICY_DESCRIPTION)
+                                .policy(MOCK_POLICY_DOCUMENT)
+                                .build()
+                ).build();
+
+        when(openSearchServerlessClient.getSecurityPolicy(any(GetSecurityPolicyRequest.class)))
+                .thenReturn(getSecurityPolicyResponse);
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(MOCK_POLICY_NAME)
+                .type(MOCK_POLICY_TYPE)
+                .description(MOCK_POLICY_DESCRIPTION)
+                .policy(MOCK_POLICY_DOCUMENT.toString())
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        assertThrows(CfnServiceLimitExceededException.class,
+                () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(openSearchServerlessClient).updateSecurityPolicy(any(UpdateSecurityPolicyRequest.class));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

Currently, in Create Handler, CFN response is resource already exists when service side exception is conflict exception.

*Description of changes:*
Update the error message for exceptions for Policy Resources.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
